### PR TITLE
Updated Mechanic MADO skills to follow kRO changes

### DIFF
--- a/data/lua files/skillinfoz/skilldescript.lub
+++ b/data/lua files/skillinfoz/skilldescript.lub
@@ -8126,7 +8126,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 3",
 		"^CC3399Requirement: Vulcan Arm 1^000000",
 		"Skill Form: ^FF0000Active / Damage^000000",
-		"Description: ^777777Set flames on the ground with a Flame Thrower to damage and inflict [Ignition] status to all targets that are inside of the range. Must have a Flame Thrower equipped. Consumes 1 Magic Gear Fuel and 20 SP.^000000",
+		"Description: ^777777Set flames on the ground with a Flame Thrower to damage and inflict [Ignition] status to all targets that are inside of the range. A [Flame Thrower] is required and Consumes 1 Magic Gear Fuel and 20 SP.^000000",
 		"[Lv 1]: ^777777Fire Property Damage 600% / Chance to curse [Ignition] status 30%^000000",
 		"[Lv 2]: ^777777Fire Property Damage 900% / Chance to curse [Ignition] status 40%^000000",
 		"[Lv 3]: ^777777Fire Property Damage 1200% / Chance to curse [Ignition] status 50%^000000"
@@ -8156,7 +8156,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 3",
 		"^CC3399Requirement: Madogear License 1^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Increase Madogear's movement speed. An Accelerator must be equipped to cast and consumes 1 Magic Gear Fuel.^000000",
+		"Description: ^777777Increase Madogear's movement speed. An [Accelerator] is required to cast and consumes 1 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^777777Skill Duration 60 sec.^000000",
 		"[Lv 2]: ^777777Skill Duration 90 sec.^000000",
 		"[Lv 3]: ^777777Skill Duration 120 sec.^000000"
@@ -8166,7 +8166,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 1",
 		"^CC3399Requirement: Acceleration 1^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Make Madogear hover over the ground to escape traps and any other magic attacks. A Hovering Booster must be equiped to cast and consumes 1 Magic Gear Fuel.^000000",
+		"Description: ^777777Make Madogear hover over the ground to escape traps and any other magic attacks. A [Hovering Booster] is required to cast and consumes 1 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^777777Skill Duration 90 sec.^000000"
 	},
 	[SKID.NC_F_SIDESLIDE] = {
@@ -8216,7 +8216,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 4",
 		"^CC3399Requirement: Remodel Mainframe 2^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Change Madogear's property. Must have a  <Shape Shifter> equipped and consumes 2 Magic Gear Fuel and 1 Enchanted Stone.^000000",
+		"Description: ^777777Change Madogear's property. A [Shape Shifter] is required and consumes 2 Magic Gear Fuel and 1 Enchanted Stone.^000000",
 		"[Lv 1]: ^777777Change to fire property / Consume 3 Scarlet Points^000000",
 		"[Lv 2]: ^777777Change to earth property / Consume 3 Lime Green Points^000000",
 		"[Lv 3]: ^777777Change to wind property / Consume 3 Yellow Wish Points^000000",
@@ -8227,7 +8227,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 1",
 		"^CC3399Requirement: Self Destruction 2^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Immediately cool down Madogear from overheating. Must have a <Cooling Device> and consumes 2 Magic Gear Fuel.^000000"
+		"Description: ^777777Immediately cool down Madogear from overheating. A [Cooling Device] is required and consumes 2 Magic Gear Fuel.^000000"
 	},
 	[SKID.NC_INFRAREDSCAN] = {
 		"Infrared Scan",
@@ -8252,7 +8252,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 3",
 		"^CC3399Requirement: Emergency Cool 1^000000",
 		"Skill Form: ^FF0000Active / Debuff^000000",
-		"Description: ^777777Immobilize all enemies that are inside of skill range with electro-magnetic waves. If caster or targets are in hovering state, they don't get skill effect. Also the magnetic field from the skill decreases target's SP continuously. Requires a <Magnetic Field Generator> and consumes 3 Magic Gear Fuel.^000000",
+		"Description: ^777777Immobilize all enemies that are inside of skill range with electro-magnetic waves. If caster or targets are in hovering state, they don't get skill effect. Also the magnetic field from the skill decreases target's SP continuously. A [Magnetic Field Generator] is required and consumes 3 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^777777Prevents movement for 4 secs. / 50 SP reduction per sec.^000000",
 		"[Lv 2]: ^777777Prevents movement for 6 secs. / 50 SP reduction per sec.^000000",
 		"[Lv 3]: ^777777Prevents movement for 8 secs. / 50 SP reduction per sec.^000000"
@@ -8262,7 +8262,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 3",
 		"^CC3399Requirement: Magnetic Field 2^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Creates an energy field around the Caster, increasing DEF and MDEF of all targets in range and preventing all Long-range attacks from damaging the targets. Requires a <Barrier Builder> and consumes 1 Magic Gear Fuel.^000000",
+		"Description: ^777777Creates an energy field around the Caster, increasing DEF and MDEF of all targets in range and preventing all Long-range attacks from damaging the targets. A [Barrier Builder] is required and consumes 1 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^777777Physical and Magic defense +15% / Duration 30 sec.^000000",
 		"[Lv 2]: ^777777Physical and Magic defense +20% / Duration 45 sec.^000000",
 		"[Lv 3]: ^777777Physical and Magic defense +25% / Duration 60 sec.^000000"
@@ -8272,7 +8272,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 3",
 		"^CC3399Requirement: Analyze 3 / Neutral Barrier 2^000000",
 		"Skill Form: ^339900Active / Buff^000000",
-		"Description: ^777777Creates a 5x5 cell stealth barrier around the Caster, cloaking all targets within range. All targets cloaked by Stealth Field will be semi-visible, and they cannot be targeted by skills. Continually consumes caster's SP while the skill is active and decreases 20% of caster's movement speed. It can be canceled if Stealth Field is cast twice. Requires a <Camouflage Generator>and consume 2 Magic Gear Fuel.^000000",
+		"Description: ^777777Creates a 5x5 cell stealth barrier around the Caster, cloaking all targets within range. All targets cloaked by Stealth Field will be semi-visible, and they cannot be targeted by skills. Continually consumes caster's SP while the skill is active and decreases 20% of caster's movement speed. It can be canceled if Stealth Field is cast twice. A [Camouflage Generator] is required and consume 2 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^77777780 SP / Duration 15 sec. / 1% SP/3 sec.^000000",
 		"[Lv 2]: ^777777100 SP / Duration 20 sec. / 1% SP/4 sec.^000000",
 		"[Lv 3]: ^777777120 SP / Duration 25 sec. / 1% SP/5 sec.^000000"
@@ -8282,7 +8282,7 @@ SKILL_DESCRIPT = {
 		"Max Level: 5",
 		"^CC3399Requirement: Madogear License 2^000000",
 		"Skill Form: ^339900Active / Recovery^000000",
-		"Description: ^777777Enable to repair (recover) Madogear or other Madogears. Requires a <Repair Kit> and consumes 1 Magic Gear Fuel.^000000",
+		"Description: ^777777Enable to repair (recover) Madogear or other Madogears. A [Repair Kit] is required and consumes 1 Magic Gear Fuel.^000000",
 		"[Lv 1]: ^777777Cast Range 5 Cell / MaxHP 4% recovery^000000",
 		"[Lv 2]: ^777777Cast Range 6 Cell / MaxHP 7% recovery^000000",
 		"[Lv 3]: ^777777Cast Range 7 Cell / MaxHP 13% recovery^000000",


### PR DESCRIPTION
> I think that is the intended behavior since:
> 
>     The following equipment reliant MADO gear skills have been changed so that you no longer require to have the item equipped, but simply need to have it in your inventory.
> 
>         Flame Launcher - Flame Thrower
>         Acceleration - Acceleration Device
>         Self Destruction - Self Destruct Device
>         Shape Shift - Shape Shift
>         Emergency Cool - Cooling Device
>         Magnetic Field - Magnetic Field Generator
>         Neutral Barrier - Barrier Generator
>         Stealth Field - Optical Camouflage Generator
>         Repair - Repair Kit
> 
> kRo Maintenance 09/02/2009
> 
> source: http://forums.irowiki.org/showthread.php?t=32980

https://github.com/rathena/rathena/issues/1034