### PR TITLE
Remove Kafra Marker

### DIFF
--- a/System/Towninfo.lub
+++ b/System/Towninfo.lub
@@ -317,7 +317,7 @@ mapNPCInfoTable = {
 	},
 -- ---------------------------------------------------------------------------- 
 	xmas = {
-		{ name = [=[Kafra Employee]=], X = 148, Y = 134, TYPE = 6, },
+		-- { name = [=[Kafra Employee]=], X = 148, Y = 134, TYPE = 6, },
 		{ name = [=[Guide]=], X = 140, Y = 137, TYPE = 4, },
 		{ name = [=[Tool Dealer]=], X = 122, Y = 131, TYPE = 0, },
 		{ name = [=[Weapon Dealer]=], X = 171, Y = 158, TYPE = 1, },


### PR DESCRIPTION
In current Renewal RO, no Kafra is located in Lutie at this location, corroborated from multiple wikis and npc database sites. 

Even server emulation lacks a Kafra at this location, so I feel it makes sense to comment it out for future clientside implementations that would pull from this repo and wonder why they have a floating icon in Lutie with no Kafra.